### PR TITLE
Fix category field in senior-together-not-alone post

### DIFF
--- a/src/Blog/posts/260408_senior-together-not-alone.md
+++ b/src/Blog/posts/260408_senior-together-not-alone.md
@@ -8,7 +8,7 @@ tags:
   - 100일글쓰기챌린지
   - 일
 description: ''
-category:
+category: 일
 ---
 
 # 한 줄 요약

--- a/src/Blog/posts/260408_senior-together-not-alone.md
+++ b/src/Blog/posts/260408_senior-together-not-alone.md
@@ -8,7 +8,6 @@ tags:
   - 100일글쓰기챌린지
   - 일
 description: ''
-category: 일
 ---
 
 # 한 줄 요약


### PR DESCRIPTION
## Summary
- Remove category field from 260408 post to fix build error

## Details
Post was missing category field causing Astro content validation to fail.
Removed the field entirely as other non-categorized posts don't have it.

## Build Status
✅ Build passes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)