### PR TITLE
ci: remove --allow-build flag not supported in pnpm 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --prefer-offline --allow-build @parcel/watcher esbuild sharp
+        run: pnpm install --prefer-offline
 
       - name: Format check
         run: pnpm format:check


### PR DESCRIPTION
Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)

Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>
