### PR TITLE
푸터 링크를 ai.sungd.uk 로 되돌림

### DIFF
--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -6,7 +6,7 @@
   <div class="site-links">
     <a href="https://sungd.uk" aria-label="Home" title="소개와 프로젝트" class="tech-link"> ⌂ home </a>
     <a href="https://resume.sungd.uk" aria-label="Resume" title="이력서" class="tech-link"> ▤ resume </a>
-    <a href="https://today.sungd.uk" aria-label="Today" title="Claude Code·Codex 큐레이션" class="tech-link"> ✦ today </a>
+    <a href="https://ai.sungd.uk" aria-label="AI" title="Claude Code·Codex 큐레이션" class="tech-link"> ✦ ai </a>
   </div>
   <div class="social-links">
     <a href="https://github.com/newhigen" target="_blank" rel="noopener noreferrer" aria-label="GitHub">


### PR DESCRIPTION
## 개요

`today.sungd.uk` 를 원래 이름 `ai.sungd.uk` 로 되돌린다. 사용자 결정이다.

today 가 살아 있던 기간이 하루도 안 돼 밖에 걸린 링크가 없고, `ai.sungd.uk` 는 그 사이 주인이 없어 404 였을 뿐이라 되돌리는 비용이 거의 없다.

## 확인

빌드가 있는 곳은 통과. 주소 문자열만 바뀌었다.