### PR TITLE
라이선스에 테마 원저작권과 내 수정분을 함께 표기

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2025 – Present 3ASH
+Copyright (c) 2025 - Present 3ASH        (astro-chiri 테마)
+Copyright (c) 2026 newhigen              (이 저장소의 수정분)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,3 +20,9 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+이 라이선스는 **코드에만** 적용된다. 아래는 대상이 아니며 저작권을 보유한다.
+
+- 글 (`src/blog-writing/`) — 서평·에세이·기술 글 전부


### PR DESCRIPTION
## 개요

네 사이트 repo 중 둘만 라이선스가 있고 둘은 없었다. 통일한다.

**"없게 통일" 은 선택지가 아니었다.** `writing.sungd.uk` 의 MIT 는 내 것이 아니라 이 사이트가 쓰는 astro-chiri 테마(3ASH) 것이다. repo 가 공개라 배포에 해당하고, MIT 는 원저작권 표시를 남기라고 요구한다. 그래서 있는 쪽으로 맞췄다.

⚠ **코드만 MIT 다.** 이력서 본문과 글까지 MIT 로 열면 누구나 복제·수정·재배포할 수 있게 된다. 그건 의도가 아니라서 본문은 대상에서 뺀다고 LICENSE 아래에 적었다.

## 확인

문서만 바뀌었다. 빌드·동작에 영향 없다.